### PR TITLE
test: add vi fixtures

### DIFF
--- a/src/__tests__/fixtures/vi/1-single-word/expected.ts
+++ b/src/__tests__/fixtures/vi/1-single-word/expected.ts
@@ -1,0 +1,40 @@
+import type { ExpectedOutputMap } from '../../../types.ts';
+
+const expectedOutputMap: ExpectedOutputMap = {
+	graphemes: {
+		total: 5,
+		by: {
+			spaces: {
+				total: 0,
+			},
+			letters: {
+				total: 4,
+			},
+			digits: {
+				total: 0,
+			},
+			punctuation: {
+				total: 1,
+			},
+			symbols: {
+				total: 0,
+			},
+		},
+		related: {
+			paragraphs: {
+				total: 1,
+			},
+			lines: {
+				total: 1,
+			},
+		},
+	},
+	words: {
+		total: 1,
+	},
+	sentences: {
+		total: 1,
+	},
+};
+
+export default expectedOutputMap;

--- a/src/__tests__/fixtures/vi/1-single-word/input.mjs
+++ b/src/__tests__/fixtures/vi/1-single-word/input.mjs
@@ -1,0 +1,1 @@
+export default 'Việt!';

--- a/src/__tests__/fixtures/vi/1-single-word/segments.ts
+++ b/src/__tests__/fixtures/vi/1-single-word/segments.ts
@@ -1,0 +1,48 @@
+// AUTO-GENERATED — DO NOT EDIT
+// Run scripts/generate-segments.mjs to regenerate
+import type { SegmentsMap } from '../../../types.ts';
+
+const segmentsMap: SegmentsMap = {
+	'graphemes': [
+		{
+			'segment': 'V',
+			'index': 0,
+		},
+		{
+			'segment': 'i',
+			'index': 1,
+		},
+		{
+			'segment': 'ệ',
+			'index': 2,
+		},
+		{
+			'segment': 't',
+			'index': 3,
+		},
+		{
+			'segment': '!',
+			'index': 4,
+		},
+	],
+	'words': [
+		{
+			'segment': 'Việt',
+			'index': 0,
+			'isWordLike': true,
+		},
+		{
+			'segment': '!',
+			'index': 4,
+			'isWordLike': false,
+		},
+	],
+	'sentences': [
+		{
+			'segment': 'Việt!',
+			'index': 0,
+		},
+	],
+};
+
+export default segmentsMap;

--- a/src/__tests__/fixtures/vi/2-single-sentence/expected.ts
+++ b/src/__tests__/fixtures/vi/2-single-sentence/expected.ts
@@ -1,0 +1,40 @@
+import type { ExpectedOutputMap } from '../../../types.ts';
+
+const expectedOutputMap: ExpectedOutputMap = {
+	graphemes: {
+		total: 24,
+		by: {
+			spaces: {
+				total: 4,
+			},
+			letters: {
+				total: 19,
+			},
+			digits: {
+				total: 0,
+			},
+			punctuation: {
+				total: 1,
+			},
+			symbols: {
+				total: 0,
+			},
+		},
+		related: {
+			paragraphs: {
+				total: 1,
+			},
+			lines: {
+				total: 1,
+			},
+		},
+	},
+	words: {
+		total: 5,
+	},
+	sentences: {
+		total: 1,
+	},
+};
+
+export default expectedOutputMap;

--- a/src/__tests__/fixtures/vi/2-single-sentence/input.mjs
+++ b/src/__tests__/fixtures/vi/2-single-sentence/input.mjs
@@ -1,0 +1,1 @@
+export default 'Tôi đang học tiếng Việt.';

--- a/src/__tests__/fixtures/vi/2-single-sentence/segments.ts
+++ b/src/__tests__/fixtures/vi/2-single-sentence/segments.ts
@@ -1,0 +1,164 @@
+// AUTO-GENERATED — DO NOT EDIT
+// Run scripts/generate-segments.mjs to regenerate
+import type { SegmentsMap } from '../../../types.ts';
+
+const segmentsMap: SegmentsMap = {
+	'graphemes': [
+		{
+			'segment': 'T',
+			'index': 0,
+		},
+		{
+			'segment': 'ô',
+			'index': 1,
+		},
+		{
+			'segment': 'i',
+			'index': 2,
+		},
+		{
+			'segment': ' ',
+			'index': 3,
+		},
+		{
+			'segment': 'đ',
+			'index': 4,
+		},
+		{
+			'segment': 'a',
+			'index': 5,
+		},
+		{
+			'segment': 'n',
+			'index': 6,
+		},
+		{
+			'segment': 'g',
+			'index': 7,
+		},
+		{
+			'segment': ' ',
+			'index': 8,
+		},
+		{
+			'segment': 'h',
+			'index': 9,
+		},
+		{
+			'segment': 'ọ',
+			'index': 10,
+		},
+		{
+			'segment': 'c',
+			'index': 11,
+		},
+		{
+			'segment': ' ',
+			'index': 12,
+		},
+		{
+			'segment': 't',
+			'index': 13,
+		},
+		{
+			'segment': 'i',
+			'index': 14,
+		},
+		{
+			'segment': 'ế',
+			'index': 15,
+		},
+		{
+			'segment': 'n',
+			'index': 16,
+		},
+		{
+			'segment': 'g',
+			'index': 17,
+		},
+		{
+			'segment': ' ',
+			'index': 18,
+		},
+		{
+			'segment': 'V',
+			'index': 19,
+		},
+		{
+			'segment': 'i',
+			'index': 20,
+		},
+		{
+			'segment': 'ệ',
+			'index': 21,
+		},
+		{
+			'segment': 't',
+			'index': 22,
+		},
+		{
+			'segment': '.',
+			'index': 23,
+		},
+	],
+	'words': [
+		{
+			'segment': 'Tôi',
+			'index': 0,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 3,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'đang',
+			'index': 4,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 8,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'học',
+			'index': 9,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 12,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'tiếng',
+			'index': 13,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 18,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'Việt',
+			'index': 19,
+			'isWordLike': true,
+		},
+		{
+			'segment': '.',
+			'index': 23,
+			'isWordLike': false,
+		},
+	],
+	'sentences': [
+		{
+			'segment': 'Tôi đang học tiếng Việt.',
+			'index': 0,
+		},
+	],
+};
+
+export default segmentsMap;

--- a/src/__tests__/fixtures/vi/3-single-sentence-w-punctuation/expected.ts
+++ b/src/__tests__/fixtures/vi/3-single-sentence-w-punctuation/expected.ts
@@ -1,0 +1,40 @@
+import type { ExpectedOutputMap } from '../../../types.ts';
+
+const expectedOutputMap: ExpectedOutputMap = {
+	graphemes: {
+		total: 33,
+		by: {
+			spaces: {
+				total: 7,
+			},
+			letters: {
+				total: 24,
+			},
+			digits: {
+				total: 0,
+			},
+			punctuation: {
+				total: 2,
+			},
+			symbols: {
+				total: 0,
+			},
+		},
+		related: {
+			paragraphs: {
+				total: 1,
+			},
+			lines: {
+				total: 1,
+			},
+		},
+	},
+	words: {
+		total: 8,
+	},
+	sentences: {
+		total: 2,
+	},
+};
+
+export default expectedOutputMap;

--- a/src/__tests__/fixtures/vi/3-single-sentence-w-punctuation/input.mjs
+++ b/src/__tests__/fixtures/vi/3-single-sentence-w-punctuation/input.mjs
@@ -1,0 +1,1 @@
+export default 'Hôm nay trời đẹp. Chúng ta đi bộ?';

--- a/src/__tests__/fixtures/vi/3-single-sentence-w-punctuation/segments.ts
+++ b/src/__tests__/fixtures/vi/3-single-sentence-w-punctuation/segments.ts
@@ -1,0 +1,239 @@
+// AUTO-GENERATED — DO NOT EDIT
+// Run scripts/generate-segments.mjs to regenerate
+import type { SegmentsMap } from '../../../types.ts';
+
+const segmentsMap: SegmentsMap = {
+	'graphemes': [
+		{
+			'segment': 'H',
+			'index': 0,
+		},
+		{
+			'segment': 'ô',
+			'index': 1,
+		},
+		{
+			'segment': 'm',
+			'index': 2,
+		},
+		{
+			'segment': ' ',
+			'index': 3,
+		},
+		{
+			'segment': 'n',
+			'index': 4,
+		},
+		{
+			'segment': 'a',
+			'index': 5,
+		},
+		{
+			'segment': 'y',
+			'index': 6,
+		},
+		{
+			'segment': ' ',
+			'index': 7,
+		},
+		{
+			'segment': 't',
+			'index': 8,
+		},
+		{
+			'segment': 'r',
+			'index': 9,
+		},
+		{
+			'segment': 'ờ',
+			'index': 10,
+		},
+		{
+			'segment': 'i',
+			'index': 11,
+		},
+		{
+			'segment': ' ',
+			'index': 12,
+		},
+		{
+			'segment': 'đ',
+			'index': 13,
+		},
+		{
+			'segment': 'ẹ',
+			'index': 14,
+		},
+		{
+			'segment': 'p',
+			'index': 15,
+		},
+		{
+			'segment': '.',
+			'index': 16,
+		},
+		{
+			'segment': ' ',
+			'index': 17,
+		},
+		{
+			'segment': 'C',
+			'index': 18,
+		},
+		{
+			'segment': 'h',
+			'index': 19,
+		},
+		{
+			'segment': 'ú',
+			'index': 20,
+		},
+		{
+			'segment': 'n',
+			'index': 21,
+		},
+		{
+			'segment': 'g',
+			'index': 22,
+		},
+		{
+			'segment': ' ',
+			'index': 23,
+		},
+		{
+			'segment': 't',
+			'index': 24,
+		},
+		{
+			'segment': 'a',
+			'index': 25,
+		},
+		{
+			'segment': ' ',
+			'index': 26,
+		},
+		{
+			'segment': 'đ',
+			'index': 27,
+		},
+		{
+			'segment': 'i',
+			'index': 28,
+		},
+		{
+			'segment': ' ',
+			'index': 29,
+		},
+		{
+			'segment': 'b',
+			'index': 30,
+		},
+		{
+			'segment': 'ộ',
+			'index': 31,
+		},
+		{
+			'segment': '?',
+			'index': 32,
+		},
+	],
+	'words': [
+		{
+			'segment': 'Hôm',
+			'index': 0,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 3,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'nay',
+			'index': 4,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 7,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'trời',
+			'index': 8,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 12,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'đẹp',
+			'index': 13,
+			'isWordLike': true,
+		},
+		{
+			'segment': '.',
+			'index': 16,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 17,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'Chúng',
+			'index': 18,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 23,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'ta',
+			'index': 24,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 26,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'đi',
+			'index': 27,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 29,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'bộ',
+			'index': 30,
+			'isWordLike': true,
+		},
+		{
+			'segment': '?',
+			'index': 32,
+			'isWordLike': false,
+		},
+	],
+	'sentences': [
+		{
+			'segment': 'Hôm nay trời đẹp. ',
+			'index': 0,
+		},
+		{
+			'segment': 'Chúng ta đi bộ?',
+			'index': 18,
+		},
+	],
+};
+
+export default segmentsMap;

--- a/src/__tests__/fixtures/vi/4-multiple-sentences/expected.ts
+++ b/src/__tests__/fixtures/vi/4-multiple-sentences/expected.ts
@@ -1,0 +1,40 @@
+import type { ExpectedOutputMap } from '../../../types.ts';
+
+const expectedOutputMap: ExpectedOutputMap = {
+	graphemes: {
+		total: 75,
+		by: {
+			spaces: {
+				total: 16,
+			},
+			letters: {
+				total: 51,
+			},
+			digits: {
+				total: 0,
+			},
+			punctuation: {
+				total: 8,
+			},
+			symbols: {
+				total: 0,
+			},
+		},
+		related: {
+			paragraphs: {
+				total: 1,
+			},
+			lines: {
+				total: 1,
+			},
+		},
+	},
+	words: {
+		total: 17,
+	},
+	sentences: {
+		total: 2,
+	},
+};
+
+export default expectedOutputMap;

--- a/src/__tests__/fixtures/vi/4-multiple-sentences/input.mjs
+++ b/src/__tests__/fixtures/vi/4-multiple-sentences/input.mjs
@@ -1,0 +1,1 @@
+export default 'Dấu sắc, huyền, hỏi, ngã, nặng đều quan trọng. Chữ đ, ơ, ư cũng là chữ cái.';

--- a/src/__tests__/fixtures/vi/4-multiple-sentences/segments.ts
+++ b/src/__tests__/fixtures/vi/4-multiple-sentences/segments.ts
@@ -1,0 +1,527 @@
+// AUTO-GENERATED — DO NOT EDIT
+// Run scripts/generate-segments.mjs to regenerate
+import type { SegmentsMap } from '../../../types.ts';
+
+const segmentsMap: SegmentsMap = {
+	'graphemes': [
+		{
+			'segment': 'D',
+			'index': 0,
+		},
+		{
+			'segment': 'ấ',
+			'index': 1,
+		},
+		{
+			'segment': 'u',
+			'index': 2,
+		},
+		{
+			'segment': ' ',
+			'index': 3,
+		},
+		{
+			'segment': 's',
+			'index': 4,
+		},
+		{
+			'segment': 'ắ',
+			'index': 5,
+		},
+		{
+			'segment': 'c',
+			'index': 6,
+		},
+		{
+			'segment': ',',
+			'index': 7,
+		},
+		{
+			'segment': ' ',
+			'index': 8,
+		},
+		{
+			'segment': 'h',
+			'index': 9,
+		},
+		{
+			'segment': 'u',
+			'index': 10,
+		},
+		{
+			'segment': 'y',
+			'index': 11,
+		},
+		{
+			'segment': 'ề',
+			'index': 12,
+		},
+		{
+			'segment': 'n',
+			'index': 13,
+		},
+		{
+			'segment': ',',
+			'index': 14,
+		},
+		{
+			'segment': ' ',
+			'index': 15,
+		},
+		{
+			'segment': 'h',
+			'index': 16,
+		},
+		{
+			'segment': 'ỏ',
+			'index': 17,
+		},
+		{
+			'segment': 'i',
+			'index': 18,
+		},
+		{
+			'segment': ',',
+			'index': 19,
+		},
+		{
+			'segment': ' ',
+			'index': 20,
+		},
+		{
+			'segment': 'n',
+			'index': 21,
+		},
+		{
+			'segment': 'g',
+			'index': 22,
+		},
+		{
+			'segment': 'ã',
+			'index': 23,
+		},
+		{
+			'segment': ',',
+			'index': 24,
+		},
+		{
+			'segment': ' ',
+			'index': 25,
+		},
+		{
+			'segment': 'n',
+			'index': 26,
+		},
+		{
+			'segment': 'ặ',
+			'index': 27,
+		},
+		{
+			'segment': 'n',
+			'index': 28,
+		},
+		{
+			'segment': 'g',
+			'index': 29,
+		},
+		{
+			'segment': ' ',
+			'index': 30,
+		},
+		{
+			'segment': 'đ',
+			'index': 31,
+		},
+		{
+			'segment': 'ề',
+			'index': 32,
+		},
+		{
+			'segment': 'u',
+			'index': 33,
+		},
+		{
+			'segment': ' ',
+			'index': 34,
+		},
+		{
+			'segment': 'q',
+			'index': 35,
+		},
+		{
+			'segment': 'u',
+			'index': 36,
+		},
+		{
+			'segment': 'a',
+			'index': 37,
+		},
+		{
+			'segment': 'n',
+			'index': 38,
+		},
+		{
+			'segment': ' ',
+			'index': 39,
+		},
+		{
+			'segment': 't',
+			'index': 40,
+		},
+		{
+			'segment': 'r',
+			'index': 41,
+		},
+		{
+			'segment': 'ọ',
+			'index': 42,
+		},
+		{
+			'segment': 'n',
+			'index': 43,
+		},
+		{
+			'segment': 'g',
+			'index': 44,
+		},
+		{
+			'segment': '.',
+			'index': 45,
+		},
+		{
+			'segment': ' ',
+			'index': 46,
+		},
+		{
+			'segment': 'C',
+			'index': 47,
+		},
+		{
+			'segment': 'h',
+			'index': 48,
+		},
+		{
+			'segment': 'ữ',
+			'index': 49,
+		},
+		{
+			'segment': ' ',
+			'index': 50,
+		},
+		{
+			'segment': 'đ',
+			'index': 51,
+		},
+		{
+			'segment': ',',
+			'index': 52,
+		},
+		{
+			'segment': ' ',
+			'index': 53,
+		},
+		{
+			'segment': 'ơ',
+			'index': 54,
+		},
+		{
+			'segment': ',',
+			'index': 55,
+		},
+		{
+			'segment': ' ',
+			'index': 56,
+		},
+		{
+			'segment': 'ư',
+			'index': 57,
+		},
+		{
+			'segment': ' ',
+			'index': 58,
+		},
+		{
+			'segment': 'c',
+			'index': 59,
+		},
+		{
+			'segment': 'ũ',
+			'index': 60,
+		},
+		{
+			'segment': 'n',
+			'index': 61,
+		},
+		{
+			'segment': 'g',
+			'index': 62,
+		},
+		{
+			'segment': ' ',
+			'index': 63,
+		},
+		{
+			'segment': 'l',
+			'index': 64,
+		},
+		{
+			'segment': 'à',
+			'index': 65,
+		},
+		{
+			'segment': ' ',
+			'index': 66,
+		},
+		{
+			'segment': 'c',
+			'index': 67,
+		},
+		{
+			'segment': 'h',
+			'index': 68,
+		},
+		{
+			'segment': 'ữ',
+			'index': 69,
+		},
+		{
+			'segment': ' ',
+			'index': 70,
+		},
+		{
+			'segment': 'c',
+			'index': 71,
+		},
+		{
+			'segment': 'á',
+			'index': 72,
+		},
+		{
+			'segment': 'i',
+			'index': 73,
+		},
+		{
+			'segment': '.',
+			'index': 74,
+		},
+	],
+	'words': [
+		{
+			'segment': 'Dấu',
+			'index': 0,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 3,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'sắc',
+			'index': 4,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 7,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 8,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'huyền',
+			'index': 9,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 14,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 15,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'hỏi',
+			'index': 16,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 19,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 20,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'ngã',
+			'index': 21,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 24,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 25,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'nặng',
+			'index': 26,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 30,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'đều',
+			'index': 31,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 34,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'quan',
+			'index': 35,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 39,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'trọng',
+			'index': 40,
+			'isWordLike': true,
+		},
+		{
+			'segment': '.',
+			'index': 45,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 46,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'Chữ',
+			'index': 47,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 50,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'đ',
+			'index': 51,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 52,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 53,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'ơ',
+			'index': 54,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 55,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 56,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'ư',
+			'index': 57,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 58,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'cũng',
+			'index': 59,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 63,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'là',
+			'index': 64,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 66,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'chữ',
+			'index': 67,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 70,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'cái',
+			'index': 71,
+			'isWordLike': true,
+		},
+		{
+			'segment': '.',
+			'index': 74,
+			'isWordLike': false,
+		},
+	],
+	'sentences': [
+		{
+			'segment': 'Dấu sắc, huyền, hỏi, ngã, nặng đều quan trọng. ',
+			'index': 0,
+		},
+		{
+			'segment': 'Chữ đ, ơ, ư cũng là chữ cái.',
+			'index': 47,
+		},
+	],
+};
+
+export default segmentsMap;

--- a/src/__tests__/fixtures/vi/5-multiple-paragraphs/expected.ts
+++ b/src/__tests__/fixtures/vi/5-multiple-paragraphs/expected.ts
@@ -1,0 +1,40 @@
+import type { ExpectedOutputMap } from '../../../types.ts';
+
+const expectedOutputMap: ExpectedOutputMap = {
+	graphemes: {
+		total: 67,
+		by: {
+			spaces: {
+				total: 13,
+			},
+			letters: {
+				total: 48,
+			},
+			digits: {
+				total: 0,
+			},
+			punctuation: {
+				total: 6,
+			},
+			symbols: {
+				total: 0,
+			},
+		},
+		related: {
+			paragraphs: {
+				total: 2,
+			},
+			lines: {
+				total: 3,
+			},
+		},
+	},
+	words: {
+		total: 13,
+	},
+	sentences: {
+		total: 3,
+	},
+};
+
+export default expectedOutputMap;

--- a/src/__tests__/fixtures/vi/5-multiple-paragraphs/input.mjs
+++ b/src/__tests__/fixtures/vi/5-multiple-paragraphs/input.mjs
@@ -1,0 +1,1 @@
+export default 'Tôi yêu tiếng Việt.\n\nDấu sắc, huyền, hỏi, ngã, nặng đều quan trọng.';

--- a/src/__tests__/fixtures/vi/5-multiple-paragraphs/segments.ts
+++ b/src/__tests__/fixtures/vi/5-multiple-paragraphs/segments.ts
@@ -1,0 +1,454 @@
+// AUTO-GENERATED — DO NOT EDIT
+// Run scripts/generate-segments.mjs to regenerate
+import type { SegmentsMap } from '../../../types.ts';
+
+const segmentsMap: SegmentsMap = {
+	'graphemes': [
+		{
+			'segment': 'T',
+			'index': 0,
+		},
+		{
+			'segment': 'ô',
+			'index': 1,
+		},
+		{
+			'segment': 'i',
+			'index': 2,
+		},
+		{
+			'segment': ' ',
+			'index': 3,
+		},
+		{
+			'segment': 'y',
+			'index': 4,
+		},
+		{
+			'segment': 'ê',
+			'index': 5,
+		},
+		{
+			'segment': 'u',
+			'index': 6,
+		},
+		{
+			'segment': ' ',
+			'index': 7,
+		},
+		{
+			'segment': 't',
+			'index': 8,
+		},
+		{
+			'segment': 'i',
+			'index': 9,
+		},
+		{
+			'segment': 'ế',
+			'index': 10,
+		},
+		{
+			'segment': 'n',
+			'index': 11,
+		},
+		{
+			'segment': 'g',
+			'index': 12,
+		},
+		{
+			'segment': ' ',
+			'index': 13,
+		},
+		{
+			'segment': 'V',
+			'index': 14,
+		},
+		{
+			'segment': 'i',
+			'index': 15,
+		},
+		{
+			'segment': 'ệ',
+			'index': 16,
+		},
+		{
+			'segment': 't',
+			'index': 17,
+		},
+		{
+			'segment': '.',
+			'index': 18,
+		},
+		{
+			'segment': '\n',
+			'index': 19,
+		},
+		{
+			'segment': '\n',
+			'index': 20,
+		},
+		{
+			'segment': 'D',
+			'index': 21,
+		},
+		{
+			'segment': 'ấ',
+			'index': 22,
+		},
+		{
+			'segment': 'u',
+			'index': 23,
+		},
+		{
+			'segment': ' ',
+			'index': 24,
+		},
+		{
+			'segment': 's',
+			'index': 25,
+		},
+		{
+			'segment': 'ắ',
+			'index': 26,
+		},
+		{
+			'segment': 'c',
+			'index': 27,
+		},
+		{
+			'segment': ',',
+			'index': 28,
+		},
+		{
+			'segment': ' ',
+			'index': 29,
+		},
+		{
+			'segment': 'h',
+			'index': 30,
+		},
+		{
+			'segment': 'u',
+			'index': 31,
+		},
+		{
+			'segment': 'y',
+			'index': 32,
+		},
+		{
+			'segment': 'ề',
+			'index': 33,
+		},
+		{
+			'segment': 'n',
+			'index': 34,
+		},
+		{
+			'segment': ',',
+			'index': 35,
+		},
+		{
+			'segment': ' ',
+			'index': 36,
+		},
+		{
+			'segment': 'h',
+			'index': 37,
+		},
+		{
+			'segment': 'ỏ',
+			'index': 38,
+		},
+		{
+			'segment': 'i',
+			'index': 39,
+		},
+		{
+			'segment': ',',
+			'index': 40,
+		},
+		{
+			'segment': ' ',
+			'index': 41,
+		},
+		{
+			'segment': 'n',
+			'index': 42,
+		},
+		{
+			'segment': 'g',
+			'index': 43,
+		},
+		{
+			'segment': 'ã',
+			'index': 44,
+		},
+		{
+			'segment': ',',
+			'index': 45,
+		},
+		{
+			'segment': ' ',
+			'index': 46,
+		},
+		{
+			'segment': 'n',
+			'index': 47,
+		},
+		{
+			'segment': 'ặ',
+			'index': 48,
+		},
+		{
+			'segment': 'n',
+			'index': 49,
+		},
+		{
+			'segment': 'g',
+			'index': 50,
+		},
+		{
+			'segment': ' ',
+			'index': 51,
+		},
+		{
+			'segment': 'đ',
+			'index': 52,
+		},
+		{
+			'segment': 'ề',
+			'index': 53,
+		},
+		{
+			'segment': 'u',
+			'index': 54,
+		},
+		{
+			'segment': ' ',
+			'index': 55,
+		},
+		{
+			'segment': 'q',
+			'index': 56,
+		},
+		{
+			'segment': 'u',
+			'index': 57,
+		},
+		{
+			'segment': 'a',
+			'index': 58,
+		},
+		{
+			'segment': 'n',
+			'index': 59,
+		},
+		{
+			'segment': ' ',
+			'index': 60,
+		},
+		{
+			'segment': 't',
+			'index': 61,
+		},
+		{
+			'segment': 'r',
+			'index': 62,
+		},
+		{
+			'segment': 'ọ',
+			'index': 63,
+		},
+		{
+			'segment': 'n',
+			'index': 64,
+		},
+		{
+			'segment': 'g',
+			'index': 65,
+		},
+		{
+			'segment': '.',
+			'index': 66,
+		},
+	],
+	'words': [
+		{
+			'segment': 'Tôi',
+			'index': 0,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 3,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'yêu',
+			'index': 4,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 7,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'tiếng',
+			'index': 8,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 13,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'Việt',
+			'index': 14,
+			'isWordLike': true,
+		},
+		{
+			'segment': '.',
+			'index': 18,
+			'isWordLike': false,
+		},
+		{
+			'segment': '\n',
+			'index': 19,
+			'isWordLike': false,
+		},
+		{
+			'segment': '\n',
+			'index': 20,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'Dấu',
+			'index': 21,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 24,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'sắc',
+			'index': 25,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 28,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 29,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'huyền',
+			'index': 30,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 35,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 36,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'hỏi',
+			'index': 37,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 40,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 41,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'ngã',
+			'index': 42,
+			'isWordLike': true,
+		},
+		{
+			'segment': ',',
+			'index': 45,
+			'isWordLike': false,
+		},
+		{
+			'segment': ' ',
+			'index': 46,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'nặng',
+			'index': 47,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 51,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'đều',
+			'index': 52,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 55,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'quan',
+			'index': 56,
+			'isWordLike': true,
+		},
+		{
+			'segment': ' ',
+			'index': 60,
+			'isWordLike': false,
+		},
+		{
+			'segment': 'trọng',
+			'index': 61,
+			'isWordLike': true,
+		},
+		{
+			'segment': '.',
+			'index': 66,
+			'isWordLike': false,
+		},
+	],
+	'sentences': [
+		{
+			'segment': 'Tôi yêu tiếng Việt.\n',
+			'index': 0,
+		},
+		{
+			'segment': '\n',
+			'index': 20,
+		},
+		{
+			'segment': 'Dấu sắc, huyền, hỏi, ngã, nặng đều quan trọng.',
+			'index': 21,
+		},
+	],
+};
+
+export default segmentsMap;


### PR DESCRIPTION
add Vietnamese fixtures for segmentation tests
closes #11 

covers:
- Vietnamese letters with tone marks
- đ ă â ê ô ơ ư
- punctuation
- sentences
- paragraphs